### PR TITLE
Release v2.2.2 with WordPress 6.9 compatibility

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: srumery
 Tags: tab, side tab, navigation, call to action, page link
 Requires at least: 6.0
 Tested up to: 6.9
-Stable tag: 6.9
+Stable tag: 2.2.2
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: srumery
 Tags: tab, side tab, navigation, call to action, page link
 Requires at least: 6.0
-Tested up to: 6.8
-Stable tag: 2.2.1
+Tested up to: 6.9
+Stable tag: 6.9
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -79,6 +79,9 @@ Use the `rum_sst_plugin_class_for_tab` filter to modify the output of the tab CS
 1. Simple Side Tab is action based on option settings
 
 == Changelog ==
+
+= 2.2.2 =
+* Tested up to: 6.9
 
 = 2.2.1 =
 * Tested up to: 6.8

--- a/simple_side_tab.php
+++ b/simple_side_tab.php
@@ -3,7 +3,7 @@
  * Plugin Name:       Simple Side Tab
  * Plugin URI:        https://rumspeed.com/wordpress-plugins/simple-side-tab/
  * Description:       Display a side tab that you can easily link to any page. Customize the tab text, font and colors. It's that simple. That's Simple Side Tab.
- * Version:           2.2.1
+ * Version:           2.2.2
  * Requires at least: 6.0
  * Requires PHP:      7.4
  * Author:            Scot Rumery
@@ -46,7 +46,7 @@ if ( ! defined( 'WPINC' ) ) {
 /**
  * Plugin constants.
  */
-define( 'SIMPLE_SIDE_TAB_VERSION', '2.2.1' );
+define( 'SIMPLE_SIDE_TAB_VERSION', '2.2.2' );
 define( 'SIMPLE_SIDE_TAB_DIR', dirname( __FILE__ ) );
 define( 'SIMPLE_SIDE_TAB_URI', plugins_url( '' , __FILE__ ) );
 define( 'SIMPLE_SIDE_TAB_BASENAME', plugin_basename(__FILE__) );


### PR DESCRIPTION
## Summary
- bump the plugin header and version constant to 2.2.2
- update readme metadata to note testing with WordPress 6.9 and adjust the stable tag
- add a changelog entry for version 2.2.2 reflecting the new tested version

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693eea2c0e748333973af0aa46c38fa4)